### PR TITLE
Enhancements: Text Wrap

### DIFF
--- a/internal/service/edit/strategy.go
+++ b/internal/service/edit/strategy.go
@@ -14,6 +14,29 @@ type EditingStrategy interface {
 
 type BlurredOverlayStrategy struct {}
 
+func wrapText(text string, maxLineLen int) string {
+	words := strings.Fields(text)
+	var lines []string
+	var currentLine string
+
+	for _, word := range words {
+		if len(currentLine)+len(word)+1 > maxLineLen {
+			lines = append(lines, currentLine)
+			currentLine = word
+		} else {
+			if currentLine != "" {
+				currentLine += " "
+			}
+			currentLine += word
+		}
+	}
+	if currentLine != "" {
+		lines = append(lines, currentLine)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
 func (b *BlurredOverlayStrategy) Process(inputPath string, outputPath string, title string) error {
 	log.Printf("Rendering video")
 	input := ffmpeg_go.Input(inputPath)
@@ -31,19 +54,34 @@ func (b *BlurredOverlayStrategy) Process(inputPath string, outputPath string, ti
 		ffmpeg_go.Args{"(W-w)/2:(H-h)/2"},
 	)
 
-	textOverlayed := overlayed.Filter("drawtext", ffmpeg_go.Args{
-		fmt.Sprintf("text=%s", strings.ToUpper(title)),
-		"fontfile=font/Montserrat-Bold.ttf",
-		"fontsize=72",
-		"fontcolor=white",
-		"x=(w-text_w)/2",
-		"y=550",
-		"borderw=10",
-		"bordercolor=black",
-	})
+	wrappedTitle := wrapText(title, 25)
+	lines := strings.Split(wrappedTitle, "\n")
+
+	lineHeight := 80
+	startY := 480
+
+	currentStream := overlayed
+
+	for i, line := range lines {
+		yPos := startY + i*lineHeight
+		// TODO: This can be a lot more elegant
+		escapedLine := strings.ReplaceAll(line, ":", "\\:")
+		escapedLine = strings.ReplaceAll(escapedLine, "\\", "\\\\")
+		currentStream = currentStream.Filter("drawtext", ffmpeg_go.Args{
+			fmt.Sprintf("text=%s", escapedLine),
+			"fontfile=font/Montserrat-Bold.ttf",
+			"fontsize=72",
+			"fontcolor=white",
+			"x=(w-text_w)/2",
+			fmt.Sprintf("y=%d", yPos),
+			"borderw=10",
+			"bordercolor=black",
+		})
+	}
 
 
-	err := ffmpeg_go.Output([]*ffmpeg_go.Stream{textOverlayed}, outputPath,
+
+	err := ffmpeg_go.Output([]*ffmpeg_go.Stream{currentStream}, outputPath,
 		ffmpeg_go.KwArgs{
 			"map":   "0:a",
 			"c:a":   "copy",


### PR DESCRIPTION
Introduces a temporary fix to wrap the title when using the drawtext filter in ffmpeg in case the title is too long. Prior to this, the text would go beyond the canvas width if it was too long. 